### PR TITLE
feat: Uses GU public API instead of dev API

### DIFF
--- a/ghpages/interactive-demo.ts
+++ b/ghpages/interactive-demo.ts
@@ -42,7 +42,7 @@ export class InteractiveDemo extends LitElement {
     if (protoId !== null && quality !== null) {
       this.updatePageImageMetadata();
     }
-    fetch('https://dev.godsunchained.com/proto?format=flat')
+    fetch('https://api.godsunchained.com/v0/proto?format=flat')
       .then((resp) => resp.json())
       .then((protos) => {
         this.protosCollection = protos;


### PR DESCRIPTION
The dev API has been deprecated and the public API provides the same
data for card protos